### PR TITLE
Update package.json with glob dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies" : {
     "jasmine-node": "*",
     "istanbul": "0.1.22",
-    "mkdirp": "0.3.x"
+    "mkdirp": "0.3.x",
+    "glob": "*"
   },
   "devDependencies" : {
     "grunt" : "~0.4.1",


### PR DESCRIPTION
fix glob dependency problem

I received the following error when running with grunt.  This change fixes the problem.

Warning: Cannot find module 'glob' Use --force to continue.
Error: Cannot find module 'glob'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at doCoverage (/home/jesse/projects/neventd/node_modules/grunt-jasmine-node-coverage/tasks/jasmine-node-task.js:10:20)
    at Object.<anonymous> (/home/jesse/projects/neventd/node_modules/grunt-jasmine-node-coverage/tasks/jasmine-node-task.js:228:13)
    at Object.thisTask.fn (/home/jesse/projects/neventd/node_modules/grunt/lib/grunt/task.js:78:16)
    at Object.<anonymous> (/home/jesse/projects/neventd/node_modules/grunt/lib/util/task.js:282:30)
    at Task.runTaskFn (/home/jesse/projects/neventd/node_modules/grunt/lib/util/task.js:235:24)
    at Task.<anonymous> (/home/jesse/projects/neventd/node_modules/grunt/lib/util/task.js:281:12)
