### PR TITLE
Added file wise coverage check

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -110,7 +110,23 @@ module.exports = function (grunt) {
                     reports.forEach(function (report) {
                         report.writeReport(collector, true);
                     });
-                    //return callback();
+                    
+                    // Check against thresholds
+                    collector.files().forEach(function (file) {
+                        var summary = istanbul.utils.summarizeFileCoverage(
+                            collector.fileCoverageFor(file));
+                        grunt.util._.each(opts.thresholds, function (threshold, metric) {
+                            var actual = summary[metric];
+                            if(!actual) {
+                                grunt.warn('unrecognized metric: ' + metric);
+                            }
+                            if(actual.pct < threshold) {
+                                grunt.warn('expected ' + metric + ' coverage to be at least '
+                                    + threshold + '% but was ' + actual.pct + '%' + '\n\tat (' + file + ')');
+                            }
+                        });
+                    });
+
                 });
                 runFn();
             });


### PR DESCRIPTION
Checks every file if it is in the configured coverage range and throws a warning if this is not the case.

Extend configuration through:

```
    jasmine_node: {
        coverage: {
            thresholds: {
                lines: 75,
                statements: 75,
                branches: 75,
                functions: 90
            }
        }, ....
```
