### PR TITLE
Bump istanbul version to ~0.1.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies" : {
     "jasmine-node": "*",
-    "istanbul": "0.1.22",
+    "istanbul": "~0.1.46",
     "mkdirp": "0.3.x",
     "glob": "~3.2.1"
   },


### PR DESCRIPTION
Some useful changes have landed in istanbul since v0.1.22.  This updates the istanbul requirement and gives a bit of future-proofing for future updates by using the tilde version range.  
