### PR TITLE
Default of jasmine-node option isVerbose corrected

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -201,7 +201,7 @@ module.exports = function (grunt) {
             var options = {
                 specFolders: specFolders,
                 onComplete: onComplete,
-                verbose: isVerbose,
+                isVerbose: isVerbose,
                 showColors: showColors,
                 teamcity: false,
                 useRequireJs: false,


### PR DESCRIPTION
I switched from grunt-jasmine-node to grunt-jasmine-node-coverage and wondered why the verbose output of the test results did not show up anymore. To fix it I could set jasmine_node.options.isVerbose to true in my grunt config but it took a while to find that out.
Your code still contains the logic that sets isVerbose to true if not set in the grunt config. However, the default is not correctly passed to jasmine-node.
