### PR TITLE
Hooking runInThisContext

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -108,6 +108,9 @@ module.exports = function (grunt) {
       hookOpts = {verbose: options.isVerbose};
 
     istanbul.hook.hookRequire(matchFn, transformer, hookOpts);
+    
+    // Hook context to ensure that all requireJS modules get instrumented.
+    // Hooking require in isolation does not appear to be sufficient.
     istanbul.hook.hookRunInThisContext(matchFn, transformer, hookOpts);
 	
     //initialize the global variable to stop mocha from complaining about leaks


### PR DESCRIPTION
I couldn't get Istanbul to instrument any modules loaded into specs using 'require' unless thisContext was also hooked, so that's what this patch is for.
