### PR TITLE
add jasmine teamcity reporter

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,8 +37,12 @@ module.exports = function (grunt) {
             spec_files: [
               '*spec.js'
             ],
-            reporter: {
-              colors: true
+            reporters: {
+              spec: {
+                colors: true
+              },
+              // Uncomment line below to activate teamcity reporter
+              //teamcity: true
             }
           }
         },

--- a/README.md
+++ b/README.md
@@ -80,10 +80,23 @@ Jasmine specific configuration. Use empty object,
 
 See the [jasmine docs](http://jasmine.github.io/2.4/node.html#section-Configuration) for more information on the supported configuration.
 
-The `reporters` property allows either `spec` property for Configuring the [Jasmine spec reporter](https://github.com/bcaudan/jasmine-spec-reporter) or `teamcity: true` for activating [Jasmine Reporters - TeamCityReporter](https://github.com/larrymyers/jasmine-reporters).
+The `reporters` property allows the one of the following properties:
+* `spec`: used to configure the [Jasmine spec reporter](https://github.com/bcaudan/jasmine-spec-reporter).
+* `teamcity` set it to `true` in order to use [Jasmine Reporters - TeamCityReporter](https://github.com/larrymyers/jasmine-reporters).
 
-If `teamcity` reporter is enabled `spec` reporter will be disabled and `teamcity` reporter will be added to the coverage reporters as well.
+If `teamcity` reporter is set `spec` reporter will be disabled and `teamcity` reporter will be added to the coverage reporters as well.
 
+Example of using `teamcity` reporter:
+```js
+{
+  spec_dir: 'spec',
+  spec_files: ['**/*[sS]pec/.js'],
+  helpers: [],
+  reporters: {
+    teamcity: true
+  }
+}
+```
 
 #### options.coverage
 

--- a/README.md
+++ b/README.md
@@ -72,13 +72,17 @@ Jasmine specific configuration. Use empty object,
   spec_dir: 'spec',
   spec_files: ['**/*[sS]pec/.js'],
   helpers: [],
-  reporter: {}
+  reporters: {
+    spec: {}
+  }
 }
 ```
 
 See the [jasmine docs](http://jasmine.github.io/2.4/node.html#section-Configuration) for more information on the supported configuration.
 
-The `reporter` property allows the [Jasmine spec reporter](https://github.com/bcaudan/jasmine-spec-reporter) to be configured.
+The `reporters` property allows either `spec` property for Configuring the [Jasmine spec reporter](https://github.com/bcaudan/jasmine-spec-reporter) or `teamcity: true` for activating [Jasmine Reporters - TeamCityReporter](https://github.com/larrymyers/jasmine-reporters).
+
+If `teamcity` reporter is enabled `spec` reporter will be disabled and `teamcity` reporter will be added to the coverage reporters as well.
 
 
 #### options.coverage

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "deepmerge": "^0.2.10",
     "istanbul": "^0.4.4",
     "jasmine": "^2.4.1",
+    "jasmine-reporters": "^2.2.0",
     "jasmine-spec-reporter": "^2.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Change the reporter option in jasmine into reporters options and moved the spec reporter to be the default reporter but add the ability to set teamcity as true in order to use teamcity reporter instead of the spec reporter.

I didn't add both teamcity and spec at the same time because both of them are writing to the console and it can be hard to understand the output.