### PR TITLE
Update deps to match latest version of jasmine-spec-reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - "4.2"
   - "6"
-  - "0.10"
 cache:
   directories:
     - node_modules

--- a/README.md
+++ b/README.md
@@ -192,9 +192,42 @@ please be as specific as possible including operating system, `node`, `grunt`, a
 npm --versions
 ```
 
-## Migrating from before `v1.0.0` release
+## Migration notes
 
-If you are updating to `v1.0.0`, you'll need to update your Gruntfile.
+### v1.x -> v2.x
+
+The `spec` reporter configuration has changed for v2 of this plugin. The following is an example of the change in configuration that is needed. This is not an exhaustive list: refer to the [jasmine-spec-reporter](https://github.com/bcaudan/jasmine-spec-reporter) for a full reference of the configuration options.
+
+``` js
+// v1
+reporters: {
+  spec: {
+    colors: true,
+    displayStacktrace: 'summary',
+    displaySuccessfulSpec: true
+  }
+}
+
+// v2
+reporters: {
+  spec: {
+    colors: {
+      enabled: true
+    },
+    summary: {
+      displayStacktrace: true
+    },
+    spec: {
+      displaySuccessful: true
+    }
+  }
+}
+```
+
+
+### v0.x -> v1.x
+
+If you are updating to `v1.x`, you'll need to update your Gruntfile.
 
 The following example outlines the changes needed. It assumes the following folder structure:
 
@@ -250,7 +283,10 @@ app/
 Please note that the junit reporter is no longer available. If you are using this reporter and wish to update to v1, please open a new issue and we'll see if we can get it added back in. Even better, submit a PR :smile:
 
 ## Release History
-
+* `unreleased`
+ - **Breaking changes alert! Ensure you read the migration guide before updating from previous versions**
+ - Updated to jasmine-spec-reporter v3.1.0. Older style configuration needs to be updated, see migration guide for more details.
+ - Removed support for Node.js v0.10
 * `v1.1.1` (2016-08-29)
   - Istanbul `v0.4.5` and using `data.src` instead of `fileSrc` for compatibility #59
 * `v1.1.0` (2016-08-23)

--- a/package.json
+++ b/package.json
@@ -37,15 +37,15 @@
     "README.md"
   ],
   "dependencies": {
-    "deepmerge": "^0.2.10",
+    "deepmerge": "^1.3.1",
     "istanbul": "^0.4.5",
-    "jasmine": "^2.4.1",
+    "jasmine": "^2.5.2",
     "jasmine-reporters": "^2.2.0",
-    "jasmine-spec-reporter": "^2.5.0"
+    "jasmine-spec-reporter": "^3.1.0"
   },
   "devDependencies": {
     "grunt": "^1.0.1",
-    "grunt-eslint": "^18.0.0"
+    "grunt-eslint": "^19.0.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.5"

--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -8,7 +8,7 @@ var fs = require('fs'),
 // 3rd party dependencies
 var istanbul = require('istanbul'),
   Jasmine = require('jasmine'),
-  SpecReporter = require('jasmine-spec-reporter'),
+  SpecReporter = require('jasmine-spec-reporter').SpecReporter,
   deepmerge = require('deepmerge'),
   reporters = require('jasmine-reporters');
 
@@ -172,6 +172,8 @@ module.exports = function jasmineNodeTask(grunt) {
   };
 
   var addReporters = function addReporters(jasmine) {
+    jasmine.env.clearReporters();
+
     var ropts = options.jasmine.reporters;
 
     var reporter;


### PR DESCRIPTION
The link in the README points to the latest version of jasmine-spec-reporter, which has undergone some breaking changes in its configuration settings. This PR updates this dependency to be consistent with the documentation.

I'd suggest bumping a major version in light of this change, as the user's grunt options need to change. For example:

```
// before
reporter: {
  colors: true,
  displayStacktrace: 'summary',
  displaySuccessfulSpec: true
}

// after
reporter: {
  colors: {
    enabled: true
  },
  summary: {
    displayStacktrace: true
  },
  spec: {
    displaySuccessful: true
  }
}
```